### PR TITLE
Use venv module for creating virtualenv

### DIFF
--- a/beokay.py
+++ b/beokay.py
@@ -84,7 +84,7 @@ def clone_kayobe(parsed_args):
 
 def create_venv(parsed_args):
     venv_path = get_path(parsed_args, "venvs", "kayobe")
-    subprocess.check_call(["virtualenv", venv_path])
+    subprocess.check_call(["python3", "-m", "venv",  venv_path])
     pip_path = os.path.join(venv_path, "bin", "pip")
     subprocess.check_call([pip_path, "install", "--upgrade", "pip"])
     subprocess.check_call([pip_path, "install", "--upgrade", "setuptools"])


### PR DESCRIPTION
The venv module landed in python 3.3. This is now the recommend way to create virtualenvs.