### PR TITLE
feat: custom venv prompt to display environment

### DIFF
--- a/beokay.py
+++ b/beokay.py
@@ -115,7 +115,7 @@ def clone_kayobe(parsed_args):
 
 def create_venv(parsed_args):
     venv_path = get_path(parsed_args, "venvs", "kayobe")
-    subprocess.check_call(["python3", "-m", "venv",  venv_path])
+    subprocess.check_call(["python3", "-m", "venv",  venv_path, "--prompt", "kayobe in \${KAYOBE_ENVIRONMENT:-base}"])
     pip_path = os.path.join(venv_path, "bin", "pip")
     subprocess.check_call([pip_path, "install", "--upgrade", "pip"])
     subprocess.check_call([pip_path, "install", "--upgrade", "setuptools"])


### PR DESCRIPTION
The `venv` module in python3 supports setting a custom prompt using the `--prompt` argument. The value of the prompt has been set to include the value of `KAYOBE_ENVIRONMENT` to notify the user of which kayobe environment has been selected.

Below is example of this change with various values of of `KAYOBE_ENVIRONMENT`.

```bash
(kayobe in base) (stackhpc/yoga=) $ source kayobe-env --environment staging
Using Kayobe config from /home/cloud-user/deployment/src/kayobe-config
Using Kayobe environment staging
(kayobe in staging) (stackhpc/yoga=) $ source kayobe-env --environment production
Using Kayobe config from /home/cloud-user/deployment/src/kayobe-config
Using Kayobe environment production
(kayobe in production) (stackhpc/yoga=) $
```
Note: This feature was added in `Python 3.6`.