### PR TITLE
fix: remove `\` in `--prompt` str

### DIFF
--- a/beokay.py
+++ b/beokay.py
@@ -137,7 +137,7 @@ def clone_kayobe(parsed_args):
 def create_venv(parsed_args):
     python = parsed_args.python
     venv_path = get_path(parsed_args, "venvs", "kayobe")
-    subprocess.check_call([python, "-m", "venv", venv_path, "--prompt", r"kayobe in \${KAYOBE_ENVIRONMENT:-base}"])
+    subprocess.check_call([python, "-m", "venv", venv_path, "--prompt", r"kayobe in ${KAYOBE_ENVIRONMENT:-base}"])
     pip_path = os.path.join(venv_path, "bin", "pip")
     subprocess.check_call([pip_path, "install", "--upgrade", "pip"])
     subprocess.check_call([pip_path, "install", "--upgrade", "setuptools"])


### PR DESCRIPTION
The resulting `bin/activate` script includes the `\` which prevents `bash` from evaluating the expression correctly.

As we are using raw strings we should not escape the `$` with a `\` otherwise it causes issues when evaluating.

Current
```
$ source deployment/env-vars.sh
Using Kayobe config from /home/cloud-user/deployment/src/kayobe-config
Using Kayobe environment ci-aio
(kayobe in ${KAYOBE_ENVIRONMENT:-base})
```

Expected
```
$ source /home/cloud-user/deployment/env-vars.sh
Using Kayobe config from /home/cloud-user/deployment/src/kayobe-config
Using Kayobe environment ci-aio
(kayobe in ci-aio)
```

This has been tested to work on `Ubuntu 22.04` with `GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)`